### PR TITLE
Make AVR specific code conditional

### DIFF
--- a/PubNub.cpp
+++ b/PubNub.cpp
@@ -1,4 +1,9 @@
+#if defined(__AVR)
 #include <avr/pgmspace.h>
+#else
+#define strncasecmp_P(a, b, c) strncasecmp(a, b, c)
+#endif
+
 #include <ctype.h>
 #include "PubNub.h"
 


### PR DESCRIPTION
- This patch check for the AVR defined symbol __AVR and conditionally
  includes avr/pgmspace.h depending on it.
- A define for strncasecmp_P set to strncasecmp was added for non-avr platforms to take
  care of the missing function.
