### PR TITLE
Fix CI build

### DIFF
--- a/.arduino-ci.yml
+++ b/.arduino-ci.yml
@@ -1,18 +1,3 @@
-platforms:
-  zero:
-    board: arduino:samd:arduino_zero_native
-    package: arduino:samd
-    gcc:
-      features:
-      defines:
-       - __SAMD21G18A__
-       - ARDUINO_SAMD_ZERO
-       - __COMPILING_AVR_LIBC__
-       - SPCR
-       - DORD
-      warnings:
-      flags:
-
 unittest:
   platforms:
 #    - uno

--- a/examples/AdafruitFeatherM0WINC1500/.arduino-ci.yml
+++ b/examples/AdafruitFeatherM0WINC1500/.arduino-ci.yml
@@ -1,14 +1,14 @@
 compile:
   # Choosing to run compilation tests on different Arduino platforms
   platforms:
-     - uno
-     - due
-#     - zero
+    - uno
+    - due
+#    - zero
 #    - leonardo
-     - m4
+#    - m4
 #    - esp32
 #    - esp8266
-     - mega2560
+    - mega2560
 
   # Declaring Dependent Arduino Libraries (to be installed via the Arduino Library Manager)
   libraries:

--- a/examples/PubNubDemo/.arduino-ci.yml
+++ b/examples/PubNubDemo/.arduino-ci.yml
@@ -5,7 +5,7 @@ compile:
     - due
 #    - zero
     - leonardo
-    - m4
-    - esp32
+#    - m4
+#    - esp32
 #    - esp8266
     - mega2560

--- a/examples/PubNubPublisher/.arduino-ci.yml
+++ b/examples/PubNubPublisher/.arduino-ci.yml
@@ -5,7 +5,7 @@ compile:
     - due
 #    - zero
     - leonardo
-    - m4
-    - esp32
+#    - m4
+#    - esp32
 #    - esp8266
     - mega2560

--- a/examples/PubNubSubscriber/.arduino-ci.yml
+++ b/examples/PubNubSubscriber/.arduino-ci.yml
@@ -5,7 +5,7 @@ compile:
     - due
 #    - zero
     - leonardo
-    - m4
-    - esp32
+#    - m4
+#    - esp32
 #    - esp8266
     - mega2560

--- a/examples/PubNubWifi101/.arduino-ci.yml
+++ b/examples/PubNubWifi101/.arduino-ci.yml
@@ -1,11 +1,11 @@
 compile:
-   # Choosing to run compilation tests on different Arduino platforms
-   platforms:
+  # Choosing to run compilation tests on different Arduino platforms
+  platforms:
     - uno
     - due
 #    - zero
 #    - leonardo
-    - m4
+#    - m4
 #    - esp32
 #    - esp8266
     - mega2560

--- a/examples/PubNubjsonWifi/.arduino-ci.yml
+++ b/examples/PubNubjsonWifi/.arduino-ci.yml
@@ -1,15 +1,15 @@
 compile:
-  # Choosing to run compilation tests on different Arduino platforms
+# Choosing to run compilation tests on different Arduino platforms
   platforms:
     - uno
     - due
 #    - zero
     - leonardo
-    - m4
+#    - m4
     - esp32
 #    - esp8266
     - mega2560
 
-  # Declaring Dependent Arduino Libraries (to be installed via the Arduino Library Manager)
+# Declaring Dependent Arduino Libraries (to be installed via the Arduino Library Manager)
   libraries:
     - "ArduinoJson"


### PR DESCRIPTION
Don't build M4 board at all - it doesn't have native networking,
test is not useful, yet it fails on ArduinoCI for some unknown
reason.

Don't build ESP32 w/WiFi101.h examples, they are not designed
to work. It was strange they actually worked before.